### PR TITLE
Update dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,13 +2,8 @@ plugins {
     `kotlin-dsl`
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
-}
-
-java {
-    targetCompatibility = JavaVersion.VERSION_11
-    sourceCompatibility = JavaVersion.VERSION_11
+kotlin {
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     implementation(stack.gradle.android.cacheFixGradlePlugin)
     implementation(stack.kotlin.gradlePlugin)
     implementation(stack.detekt.gradlePlugin)
-    implementation(libs.android.gradlePlugin)
+    implementation(stack.android.tools.build.gradle)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -8,14 +8,14 @@ pluginManagement {
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
 
     repositories {
         google {
             content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
             }
         }
 

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
     }
 
     versionCatalogs {
-        val version = "2024.04.10"
+        val version = "2024.08.01"
         create("rmr") {
             from("com.redmadrobot.versions:versions-redmadrobot:$version")
         }

--- a/buildSrc/src/main/kotlin/convention.detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.detekt.gradle.kts
@@ -1,15 +1,5 @@
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-
 plugins {
     id("io.gitlab.arturbosch.detekt")
-}
-
-tasks.withType<Detekt>().configureEach {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<DetektCreateBaselineTask>().configureEach {
-    jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/convention.jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.jvm.gradle.kts
@@ -1,0 +1,14 @@
+import com.redmadrobot.build.dsl.isRunningOnCi
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+kotlinExtension.jvmToolchain(11)
+
+// Treat all warnings as errors on CI
+val warningsAsErrors = findProperty("warningsAsErrors") == "true" || isRunningOnCi
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        allWarningsAsErrors = warningsAsErrors
+    }
+}

--- a/buildSrc/src/main/kotlin/convention.library.android.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.library.android.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     compileSdk = 34
-    defaultConfig.minSdk = 19
+    defaultConfig.minSdk = 21
 }
 
 kotlin {

--- a/buildSrc/src/main/kotlin/convention.library.android.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.library.android.gradle.kts
@@ -1,9 +1,17 @@
 plugins {
-    id("com.redmadrobot.android-library")
+    id("com.android.library")
+    kotlin("android")
+    id("org.gradle.android.cache-fix")
+    id("convention.jvm")
     id("convention.publishing")
     id("convention.detekt")
 }
 
-redmadrobot {
-    android.minSdk = 19
+android {
+    compileSdk = 34
+    defaultConfig.minSdk = 19
+}
+
+kotlin {
+    explicitApi()
 }

--- a/buildSrc/src/main/kotlin/convention.library.kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.library.kotlin.gradle.kts
@@ -1,5 +1,10 @@
 plugins {
-    id("com.redmadrobot.kotlin-library")
+    kotlin("jvm")
+    id("convention.jvm")
     id("convention.publishing")
     id("convention.detekt")
+}
+
+kotlin {
+    explicitApi()
 }

--- a/buildSrc/src/main/kotlin/convention.library.ktx.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.library.ktx.gradle.kts
@@ -1,11 +1,9 @@
-import com.redmadrobot.build.dsl.kotlinCompile
-
 plugins {
     id("convention.library.android")
 }
 
-kotlinCompile {
-    kotlinOptions {
-        moduleName = "redmadrobot.${project.name}"
+kotlin {
+    compilerOptions {
+        "redmadrobot.${project.name}"
     }
 }

--- a/gears/gears-compose/README.md
+++ b/gears/gears-compose/README.md
@@ -1,6 +1,9 @@
 # gears-compose <GitHub path="RedMadRobot/gears-android/tree/main/gears/compose"/>
+
 [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.gears/gears-compose?style=flat-square)][mavenCentral]
 [![License](https://img.shields.io/github/license/RedMadRobot/gears-android?style=flat-square)][license]
+
+A set of gears for Jetpack Compose.
 
 ---
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -11,8 +14,6 @@
 - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-A set of gears for compose.
 
 ## Installation
 

--- a/gears/gears-compose/build.gradle.kts
+++ b/gears/gears-compose/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     convention.library.android
+    alias(stack.plugins.kotlin.compose)
 }
 
 version = "0.1.0"
@@ -9,14 +10,6 @@ android {
     namespace = "$group.compose"
 
     defaultConfig.minSdk = 21
-
-    buildFeatures {
-        compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = androidx.versions.compose.compiler.get()
-    }
 }
 
 dependencies {

--- a/gears/gears-compose/build.gradle.kts
+++ b/gears/gears-compose/build.gradle.kts
@@ -5,12 +5,10 @@ plugins {
 version = "0.1.0"
 description = "A set of gears for compose"
 
-redmadrobot {
-    android.minSdk = 21
-}
-
 android {
     namespace = "$group.compose"
+
+    defaultConfig.minSdk = 21
 
     buildFeatures {
         compose = true

--- a/gears/gears-compose/build.gradle.kts
+++ b/gears/gears-compose/build.gradle.kts
@@ -8,8 +8,6 @@ description = "A set of gears for compose"
 
 android {
     namespace = "$group.compose"
-
-    defaultConfig.minSdk = 21
 }
 
 dependencies {

--- a/gears/gears-compose/build.gradle.kts
+++ b/gears/gears-compose/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 version = "0.1.0"
-description = "A set of gears for compose"
+description = "A set of gears for Jetpack Compose"
 
 android {
     namespace = "$group.compose"

--- a/gears/gears-kotlin/README.md
+++ b/gears/gears-kotlin/README.md
@@ -1,6 +1,9 @@
 # gears-kotlin <GitHub path="RedMadRobot/gears-android/tree/main/gears/kotlin"/>
+
 [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.gears/kotlin?style=flat-square)][mavenCentral]
 [![License](https://img.shields.io/github/license/RedMadRobot/gears-android?style=flat-square)][license]
+
+A set of gears for Kotlin.
 
 ---
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -11,8 +14,6 @@
 - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-A set of gears for kotlin.
 
 ## Installation
 

--- a/gears/gears-kotlin/build.gradle.kts
+++ b/gears/gears-kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 version = "0.1.0"
-description = "A set of gears for kotlin"
+description = "A set of gears for Kotlin"
 
 dependencies {
     api(kotlin("stdlib"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,11 @@
 [versions]
-androidGradlePlugin = "8.4.1"
 assertj-core = "3.25.1"
 androidx-arch-core = "2.2.0"
-viewbinding = "8.4.1"
-publish-plugin = "0.28.0"
+viewbinding = "8.5.1"
+publish-plugin = "0.29.0"
 
 [libraries]
 androidx-viewbinding = { module = "androidx.databinding:viewbinding", version.ref = "viewbinding" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core"}
-android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 publish-gradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publish-plugin" }

--- a/ktx/core-ktx/CHANGELOG.md
+++ b/ktx/core-ktx/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Changes
+
+- `minSdk` version changed 19 → 21
 - **SharedPreferences**: Removed nullable accessors with default parameter
 - **Context**: Added `Context.findActivity()` and `Context.findWindow()` extensions
 

--- a/ktx/fragment-args-ktx/CHANGELOG.md
+++ b/ktx/fragment-args-ktx/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Changes
+
+- `minSdk` version changed 19 → 21
 - **Bundle**: Removed nullable accessors with default parameter
 - **Bundle**: Accessors for `Serializable` and `Parcelizable` are turned into inline-functions
 

--- a/ktx/fragment-ktx/CHANGELOG.md
+++ b/ktx/fragment-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changes
+
+- `minSdk` version changed 19 → 21
+
 ## [1.3.6-0] (2021-10-02)
 
 ### Dependencies

--- a/ktx/lifecycle-livedata-ktx/CHANGELOG.md
+++ b/ktx/lifecycle-livedata-ktx/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changes
 
+- `minSdk` version changed 19 → 21
 - **Breaking change!** `EventQueue` has been moved to a separate module and renamed to `ViewModelEvents`. See the appropriate [documentation](../../viewmodelevents/README.md)
 
 ### Dependencies

--- a/ktx/resources-ktx/CHANGELOG.md
+++ b/ktx/resources-ktx/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- `minSdk` version changed 19 → 21
 - **Breaking change**: `Text` moved to a separate library [com.redmadrobot.textvalue](https://github.com/RedMadRobot/TextValue).
 
 ## [1.3.1-0] (2021-10-03)

--- a/ktx/viewbinding-ktx/CHANGELOG.md
+++ b/ktx/viewbinding-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changes
+
+- `minSdk` version changed 19 → 21
+
 ### Dependencies
 
 - androidx.fragment 1.3.5 -> 1.3.6

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,13 +1,28 @@
 pluginManagement {
     repositories {
-        google()
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
         gradlePluginPortal()
     }
 }
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
     repositories {
+        google {
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
         mavenCentral()
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage", "StringLiteralDuplication")
+
 pluginManagement {
     repositories {
         google {
@@ -11,7 +13,10 @@ pluginManagement {
     }
 }
 
-@Suppress("UnstableApiUsage")
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
 
@@ -27,7 +32,7 @@ dependencyResolutionManagement {
     }
 
     versionCatalogs {
-        val version = "2024.04.10"
+        val version = "2024.08.01"
         create("rmr") {
             from("com.redmadrobot.versions:versions-redmadrobot:$version")
         }

--- a/viewmodelevents/viewmodelevents-compose/build.gradle.kts
+++ b/viewmodelevents/viewmodelevents-compose/build.gradle.kts
@@ -1,19 +1,12 @@
 plugins {
     convention.library.android
+    alias(stack.plugins.kotlin.compose)
 }
 
 description = "ViewModelEvents extensions for compose"
 
 android {
     namespace = "$group.compose"
-
-    buildFeatures {
-        compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = androidx.versions.compose.compiler.get()
-    }
 }
 
 dependencies {


### PR DESCRIPTION
- Update Kotlin to 2.0.0
- Migrate to new Compose Compiler plugin
- Update AGP
- Update infrastructure to 0.19.1
- Change `minSdk` from 19 to 21